### PR TITLE
fix: Check for contracts on low-level calls (SC-4179)

### DIFF
--- a/contracts/Proxied.sol
+++ b/contracts/Proxied.sol
@@ -13,6 +13,14 @@ contract Proxied is SlotManipulatable {
     bytes32 private constant IMPLEMENTATION_SLOT = bytes32(0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc);
 
     function _migrate(address migrator_, bytes calldata arguments_) internal virtual returns (bool success_) {
+        uint256 size;
+
+        assembly {
+            size := extcodesize(migrator_)
+        }
+
+        if (size == uint256(0)) return false;
+
         ( success_, ) = migrator_.delegatecall(arguments_);
     }
 

--- a/contracts/test/ProxyFactory.t.sol
+++ b/contracts/test/ProxyFactory.t.sol
@@ -181,6 +181,10 @@ contract ProxyFactoryTests is DSTest {
 
     // TODO: test_registerMigrator_unset
 
+    function testFail_registerMigrator_withInvalidMigrator() external {
+        (new MockFactory()).registerMigrator(1, 2, address(1));
+    }
+
     function test_upgradeInstance_withNoMigration() external {
         MockFactory          factory          = new MockFactory();
         MockInitializerV1    initializerV1    = new MockInitializerV1();


### PR DESCRIPTION
# Description

- check migrator is contact in`Proxied.migrate`
- check proxy is contract in`ProxyFactory._initializeInstance`
- check implementation is contract in`ProxyFactory._registerImplementation`
- check migrator is contract in `ProxyFactory._registerMigrator`

# Integrations Checklist

- [ ] Have any function signatures changed? If yes, outline below.
- [ ] Have any features changed or been added? If yes, outline below.
- [ ] Have any events changed or been added? If yes, outline below.
- [ ] Has all documentation been updated?

# Changelog
## Function Signature Changes

## Features 

## Events

