### PR TITLE
feat: Cleanup and Fixes

### DIFF
--- a/config/ci.json
+++ b/config/ci.json
@@ -1,35 +1,35 @@
 {
-  "language": "Solidity",
-  "sources": {
-    "contracts/ProxyFactory.sol": {
-      "urls": ["contracts/ProxyFactory.sol"]
+    "language": "Solidity",
+    "sources": {
+        "contracts/ProxyFactory.sol": {
+            "urls": ["contracts/ProxyFactory.sol"]
+        },
+        "contracts/test/ProxyFactory.t.sol": {
+            "urls": ["contracts/test/ProxyFactory.t.sol"]
+        },
+        "contracts/test/SlotManipulatable.t.sol": {
+            "urls": [
+                "contracts/test/SlotManipulatable.t.sol"
+            ]
+        }
     },
-    "contracts/test/ProxyFactory.t.sol": {
-      "urls": ["contracts/test/ProxyFactory.t.sol"]
-    },
-    "contracts/test/SlotManipulatable.t.sol": {
-      "urls": [
-        "contracts/test/SlotManipulatable.t.sol"
-      ]
+    "settings": {
+        "optimizer": {
+            "enabled": true,
+            "runs": 200
+        },
+        "outputSelection": {
+            "*": {
+                "*": [
+                    "abi",
+                    "evm.bytecode",
+                    "evm.deployedBytecode"
+                ],
+                "": ["ast"]
+            }
+        },
+        "metadata": {
+            "bytecodeHash": "none"
+        }
     }
-  },
-  "settings": {
-    "optimizer": {
-      "enabled": true,
-      "runs": 200
-    },
-    "outputSelection": {
-      "*": {
-        "*": [
-          "abi",
-          "evm.bytecode",
-          "evm.deployedBytecode"
-        ],
-        "": ["ast"]
-      }
-    },
-    "metadata": {
-      "bytecodeHash": "none"
-    }
-  }
 }

--- a/config/dev.json
+++ b/config/dev.json
@@ -1,37 +1,37 @@
 {
-  "language": "Solidity",
-  "sources": {
-    "contracts/ProxyFactory.sol": {
-      "urls": ["contracts/ProxyFactory.sol"]
+    "language": "Solidity",
+    "sources": {
+        "contracts/ProxyFactory.sol": {
+            "urls": ["contracts/ProxyFactory.sol"]
+        },
+        "contracts/test/ProxyFactory.t.sol": {
+            "urls": ["contracts/test/ProxyFactory.t.sol"]
+        },
+        "contracts/test/SlotManipulatable.t.sol": {
+            "urls": [
+                "contracts/test/SlotManipulatable.t.sol"
+            ]
+        }
     },
-    "contracts/test/ProxyFactory.t.sol": {
-      "urls": ["contracts/test/ProxyFactory.t.sol"]
-    },
-    "contracts/test/SlotManipulatable.t.sol": {
-      "urls": [
-        "contracts/test/SlotManipulatable.t.sol"
-      ]
+    "settings": {
+        "optimizer": {
+            "enabled": true,
+            "runs": 200
+        },
+        "outputSelection": {
+            "*": {
+                "*": [
+                    "abi",
+                    "metadata",
+                    "evm.bytecode",
+                    "evm.deployedBytecode",
+                    "evm.gasEstimates"
+                ],
+                "": ["ast"]
+            }
+        },
+        "metadata": {
+            "bytecodeHash": "none"
+        }
     }
-  },
-  "settings": {
-    "optimizer": {
-      "enabled": true,
-      "runs": 200
-    },
-    "outputSelection": {
-      "*": {
-        "*": [
-          "abi",
-          "metadata",
-          "evm.bytecode",
-          "evm.deployedBytecode",
-          "evm.gasEstimates"
-        ],
-        "": ["ast"]
-      }
-    },
-    "metadata": {
-      "bytecodeHash": "none"
-    }
-  }
 }

--- a/config/prod.json
+++ b/config/prod.json
@@ -1,31 +1,31 @@
 {
-  "language": "Solidity",
-  "sources": {
-    "contracts/ProxyFactory.sol": {
-      "urls": ["contracts/ProxyFactory.sol"]
-    }
-  },
-  "settings": {
-    "optimizer": {
-      "enabled": true,
-      "runs": 200
+    "language": "Solidity",
+    "sources": {
+        "contracts/ProxyFactory.sol": {
+            "urls": ["contracts/ProxyFactory.sol"]
+        }
     },
-    "outputSelection": {
-      "*": {
-        "*": [
-          "abi",
-          "devdoc",
-          "userdoc",
-          "metadata",
-          "evm.bytecode",
-          "evm.deployedBytecode",
-          "evm.gasEstimates"
-        ],
-        "": ["ast"]
-      }
-    },
-    "metadata": {
-      "bytecodeHash": "none"
+    "settings": {
+        "optimizer": {
+            "enabled": true,
+            "runs": 200
+        },
+        "outputSelection": {
+            "*": {
+                "*": [
+                    "abi",
+                    "devdoc",
+                    "userdoc",
+                    "metadata",
+                    "evm.bytecode",
+                    "evm.deployedBytecode",
+                    "evm.gasEstimates"
+                ],
+                "": ["ast"]
+            }
+        },
+        "metadata": {
+            "bytecodeHash": "none"
+        }
     }
-  }
 }

--- a/contracts/Proxy.sol
+++ b/contracts/Proxy.sol
@@ -18,24 +18,23 @@ contract Proxy is SlotManipulatable {
         _setSlotValue(FACTORY_SLOT, bytes32(uint256(uint160(factory_))));
 
         // If the implementation is empty, fetch it from the factory, which can act as a beacon.
-        _setSlotValue(
-            IMPLEMENTATION_SLOT,
-            bytes32(uint256(uint160(
-                implementation_ == address(0) ? IDefaultImplementationBeacon(factory_).defaultImplementation() : implementation_
-            )))
-        );
+        address implementation = implementation_ == address(0) ? IDefaultImplementationBeacon(factory_).defaultImplementation() : implementation_;
+
+        require(implementation != address(0), "P:C:INVALID_IMPLEMENTATION");
+
+        _setSlotValue(IMPLEMENTATION_SLOT, bytes32(uint256(uint160(implementation))));
     }
 
     fallback() payable external virtual {
         bytes32 implementation = _getSlotValue(IMPLEMENTATION_SLOT);
 
-        int256 size;
+        uint256 size;
 
         assembly {
             size := extcodesize(implementation)
         }
 
-        require(size != 0, "P:F:INVALID_IMPLEMENTATION");
+        require(size != uint256(0), "P:F:INVALID_IMPLEMENTATION");
 
         assembly {
             calldatacopy(0, 0, calldatasize())

--- a/contracts/ProxyFactory.sol
+++ b/contracts/ProxyFactory.sol
@@ -8,51 +8,90 @@ import { Proxy } from "./Proxy.sol";
 /// @title A factory for Proxy contracts that proxy Proxied implementations.
 contract ProxyFactory {
 
-    bytes32 internal constant PROXY_CODE_HASH = keccak256(type(Proxy).runtimeCode);
-
     mapping(uint256 => address) internal _implementationOf;
 
     mapping(address => uint256) internal _versionOf;
 
     mapping(uint256 => mapping(uint256 => address)) internal _migratorForPath;
 
-    function _initializeInstance(address proxy_, uint256 version_, bytes memory arguments_) internal virtual returns (bool success_) {
-        if (!_isContract(proxy_)) return false;
+    /// @dev Returns the implementation of `proxy_`.
+    function _getImplementationOfProxy(address proxy_) private returns (bool success_, address implementation_) {
+        bytes memory returnData;
+        // Since `_getImplementationOfProxy` is a private function, no need to check `proxy_` is a contract.
+        ( success_, returnData ) = proxy_.call(abi.encodeWithSelector(IProxied.implementation.selector));
+        implementation_ = abi.decode(returnData, (address));
+    }
 
+    /// @dev Initializes `proxy_` using the initializer for `version_`, given some initialization arguments.
+    function _initializeInstance(address proxy_, uint256 version_, bytes memory arguments_) private returns (bool success_) {
+        // The migrator, where fromVersion == toVersion, is an initializer.
         address initializer = _migratorForPath[version_][version_];
 
-        if (initializer == address(0)) return true;
+        // If there is no initializer, then no initialization is necessary, so long as no initialization arguments were provided.
+        if (initializer == address(0)) return arguments_.length == uint256(0);
 
+        // Call the migrate function on the proxy, passing any initialization arguments.
+        // Since `_initializeInstance` is a private function, no need to check `proxy_` is a contract.
         ( success_, ) = proxy_.call(abi.encodeWithSelector(IProxied.migrate.selector, initializer, arguments_));
     }
 
+    /// @dev Deploys a new proxy for some version, with some initialization arguments, using `create` (i.e. factory's nonce determines the address).
     function _newInstance(uint256 version_, bytes memory arguments_) internal virtual returns (bool success_, address proxy_) {
         address implementation = _implementationOf[version_];
 
-        success_ =
-            implementation != address(0) &&
-            _initializeInstance(proxy_ = address(new Proxy(address(this), implementation)), version_, arguments_);
+        if (implementation == address(0)) return (false, address(0));
+
+        // Build the Proxy creation code in memory, with the factory and implementation as arguments.
+        bytes memory creationCode = abi.encodePacked(type(Proxy).creationCode, abi.encode(address(this), implementation));
+
+        assembly { proxy_ := create(0, add(creationCode, 0x20), mload(creationCode)) }
+
+        // Successful if proxy is nonzero and initializing the instance succeeds.
+        success_ = (proxy_ != address(0)) && _initializeInstance(proxy_, version_, arguments_);
     }
 
-    function _newInstance(uint256 version_, bytes memory arguments_, bytes32 salt_) internal virtual returns (bool success_, address proxy_) {
-        address implementation = _implementationOf[version_];
+    /// @dev Deploys a new proxy, with some initialization arguments, using `create2` (i.e. salt determines the address).
+    ///      This factory needs to be IDefaultImplementationBeacon, since the proxy will pull its implementation from it.
+    function _newInstance(bytes memory arguments_, bytes32 salt_) internal virtual returns (bool success_, address proxy_) {
+        // Build the Proxy creation code in memory, with the factory and implementation as arguments.
+        bytes memory creationCode = abi.encodePacked(type(Proxy).creationCode, abi.encode(address(this), address(0)));
 
-        success_ =
-            implementation != address(0) &&
-            _initializeInstance(proxy_ = address(new Proxy{ salt: salt_ }(address(this), address(0))), version_, arguments_);
+        assembly { proxy_ := create2(0, add(creationCode, 0x20), mload(creationCode), salt_) }
+
+        // Fetch the implementation from the proxy. Don't care about success since the version later will be checked shortly.
+        ( , address implementation ) = _getImplementationOfProxy(proxy_);
+
+        // Get the version of the implementation, decoded as the only return value from the previous low-level call.
+        uint256 version = _versionOf[implementation];
+
+        // Successful if version is nonzero (i.e. implementation fetched successfully from proxy) and initializing the instance succeeds.
+        success_ = (version != uint256(0)) && _initializeInstance(proxy_, version, arguments_);
     }
 
-    function _registerImplementation(uint256 version_, address implementationAddress_) internal virtual returns (bool success_) {
-        // Cannot already be registered and cannot be empty implementation.
-        if (_implementationOf[version_] != address(0) || !_isContract(implementationAddress_)) return false;
+    /// @dev Registers an implementation for some version.
+    function _registerImplementation(uint256 version_, address implementation_) internal virtual returns (bool success_) {
+        // Version 0 is not allowed since its the default value of all _versionOf[implementation_].
+        // Implementation cannot already be registered and cannot be empty account (and thus also not address(0)).
+        if (
+            version_ == uint256(0) ||
+            _implementationOf[version_] != address(0) ||
+            _versionOf[implementation_] != uint256(0) ||
+            !_isContract(implementation_)
+        ) return false;
 
-        _versionOf[implementationAddress_] = version_;
-        _implementationOf[version_]        = implementationAddress_;
+        // Store in two-way mappings.
+        _versionOf[implementation_] = version_;
+        _implementationOf[version_] = implementation_;
 
         return true;
     }
 
+    /// @dev Registers a migrator for between two versions. If `fromVersion_ == toVersion_`, migrator is an initializer.
     function _registerMigrator(uint256 fromVersion_, uint256 toVersion_, address migrator_) internal virtual returns (bool success_) {
+        // Version 0 is invalid.
+        if (fromVersion_ == uint256(0) || toVersion_ == uint256(0)) return false;
+
+        // Migrator must either be zero (clearing) or a contract (setting).
         if (migrator_ != address(0) && !_isContract(migrator_)) return false;
 
         _migratorForPath[fromVersion_][toVersion_] = migrator_;
@@ -60,32 +99,39 @@ contract ProxyFactory {
         return true;
     }
 
+    /// @dev Upgrades a proxy to a new version of an implementation, with some migration arguments.
     function _upgradeInstance(address proxy_, uint256 toVersion_, bytes memory arguments_) internal virtual returns (bool success_) {
+        // Check that the proxy is currently a contract, just once, ahead of the 3 times it will be low-level-called.
         if (!_isContract(proxy_)) return false;
 
         address toImplementation = _implementationOf[toVersion_];
 
+        // The implementation being migrated must have been registered (which also implies that `toVersion_` was not 0).
         if (toImplementation == address(0)) return false;
 
-        bytes memory returnData;
-
-        ( success_, returnData ) = proxy_.call(abi.encodeWithSelector(IProxied.implementation.selector));
+        // Fetch the implementation from the proxy.
+        address fromImplementation;
+        ( success_, fromImplementation ) = _getImplementationOfProxy(proxy_);
 
         if (!success_) return false;
 
+        // Set the proxy's implementation.
         ( success_, ) = proxy_.call(abi.encodeWithSelector(IProxied.setImplementation.selector, toImplementation));
 
         if (!success_) return false;
 
-        // Get the "fromImplementation" from `returnData`, then the version of the "fromImplementation", then get the `migrator` of the upgrade path.
-        address migrator = _migratorForPath[_versionOf[abi.decode(returnData, (address))]][toVersion_];
+        // Get the version of the `fromImplementation`, then get the `migrator` of the upgrade path to `toVersion_`.
+        address migrator = _migratorForPath[_versionOf[fromImplementation]][toVersion_];
 
-        if (migrator == address(0)) return true;
+        // If there is no migrator, then no migration is necessary, so long as no migration arguments were provided.
+        if (migrator == address(0)) return arguments_.length == uint256(0);
 
+        // Call the migrate function on the proxy, passing any migration arguments.
         ( success_, ) = proxy_.call(abi.encodeWithSelector(IProxied.migrate.selector, migrator, arguments_));
     }
 
-    function _getDeterministicProxyAddress(bytes32 salt_) internal virtual view returns (address proxyAddress_) {
+    /// @dev Returns the deterministic address of a proxy given some salt.
+    function _getDeterministicProxyAddress(bytes32 salt_) internal virtual view returns (address deterministicProxyAddress_) {
         // See https://docs.soliditylang.org/en/v0.8.7/control-structures.html#salted-contract-creations-create2
         return address(
             uint160(
@@ -103,7 +149,8 @@ contract ProxyFactory {
         );
     }
 
-    function _isContract(address account_) internal view returns (bool) {
+    /// @dev Returns whether the account is currently a contract.
+    function _isContract(address account_) internal view returns (bool isContract_) {
         uint256 size;
 
         assembly {

--- a/contracts/test/ProxyFactory.t.sol
+++ b/contracts/test/ProxyFactory.t.sol
@@ -153,8 +153,8 @@ contract ProxyFactoryTests is DSTest {
 
         bytes32 salt = keccak256(abi.encodePacked("salt"));
 
-        assertEq(factory.getDeterministicProxyAddress(salt), 0x14FA484Bd9D11d9d970226a7b9FD03A5ae37Be60);
-        assertEq(factory.newInstance(1, new bytes(0), salt), 0x14FA484Bd9D11d9d970226a7b9FD03A5ae37Be60);
+        assertEq(factory.getDeterministicProxyAddress(salt), 0x01E7fFbDA7F30087c376259c0771577D4c4a57b1);
+        assertEq(factory.newInstance(new bytes(0), salt),    0x01E7fFbDA7F30087c376259c0771577D4c4a57b1);
     }
 
     // TODO: test_newInstanceWithSalt_withNoInitializationArgs
@@ -174,8 +174,8 @@ contract ProxyFactoryTests is DSTest {
         bytes32 salt = keccak256(abi.encodePacked("salt"));
 
         factory.registerImplementation(1, address(implementation));
-        factory.newInstance(1, new bytes(0), salt);
-        factory.newInstance(1, new bytes(0), salt);
+        factory.newInstance(new bytes(0), salt);
+        factory.newInstance(new bytes(0), salt);
     }
 
     // TODO: test_registerMigrator_set

--- a/contracts/test/mocks/Mocks.sol
+++ b/contracts/test/mocks/Mocks.sol
@@ -24,8 +24,8 @@ contract MockFactory is IDefaultImplementationBeacon, ProxyFactory {
         return _versionOf[proxy_];
     }
 
-    function registerImplementation(uint256 version_, address implementationAddress_) external {
-        require(_registerImplementation(version_, defaultImplementation = implementationAddress_));
+    function registerImplementation(uint256 version_, address implementation_) external {
+        require(_registerImplementation(version_, defaultImplementation = implementation_));
     }
 
     function newInstance(uint256 version_, bytes calldata initializationArguments_) external returns (address proxy_) {
@@ -34,9 +34,9 @@ contract MockFactory is IDefaultImplementationBeacon, ProxyFactory {
         require(success);
     }
 
-    function newInstance(uint256 version_, bytes calldata initializationArguments_, bytes32 salt_) external returns (address proxy_) {
+    function newInstance(bytes calldata initializationArguments_, bytes32 salt_) external returns (address proxy_) {
         bool success;
-        ( success, proxy_ ) = _newInstance(version_, initializationArguments_, salt_);
+        ( success, proxy_ ) = _newInstance(initializationArguments_, salt_);
         require(success);
     }
 


### PR DESCRIPTION
- Proxy constructor reverts if implementation is zero even after fetching from Factory
- int256 -> uint256 contract size in Proxy
- removed deprecated `PROXY_CODE_HASH` from Factory
- made `_initializeInstance` private and only called internally, so no need to check proxy contract size
- moved reused code into a private `_getImplementationOfProxy` function that also does not need to check proxy contract size
- `_initializeInstance` and `_upgradeInstance` now return false if no initializer/migrator but has arguments
- all deploys and calls low-level in order to not have reverts and bubble up all successes to inheritor
- cleaned up logic and optimized
- version 0 now explicitly banned
- prevent re-registering implementation as new version
- added many comments

# Description

# Integrations Checklist

- [ ] Have any function signatures changed? If yes, outline below.
- [ ] Have any features changed or been added? If yes, outline below.
- [ ] Have any events changed or been added? If yes, outline below.
- [ ] Has all documentation been updated?

# Changelog
## Function Signature Changes

## Features 

## Events

