### PR TITLE
chore: Cleanup everything and add inline comments

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,7 +10,7 @@
 # Changelog
 ## Function Signature Changes
 
-## Features 
+## Features
 
 ## Events
 

--- a/config/ci.json
+++ b/config/ci.json
@@ -1,35 +1,35 @@
 {
-  "language": "Solidity",
-  "sources": {
-    "contracts/ProxyFactory.sol": {
-      "urls": ["contracts/ProxyFactory.sol"]
+    "language": "Solidity",
+    "sources": {
+        "contracts/ProxyFactory.sol": {
+            "urls": ["contracts/ProxyFactory.sol"]
+        },
+        "contracts/test/ProxyFactory.t.sol": {
+            "urls": ["contracts/test/ProxyFactory.t.sol"]
+        },
+        "contracts/test/SlotManipulatable.t.sol": {
+            "urls": [
+                "contracts/test/SlotManipulatable.t.sol"
+            ]
+        }
     },
-    "contracts/test/ProxyFactory.t.sol": {
-      "urls": ["contracts/test/ProxyFactory.t.sol"]
-    },
-    "contracts/test/SlotManipulatable.t.sol": {
-      "urls": [
-        "contracts/test/SlotManipulatable.t.sol"
-      ]
+    "settings": {
+        "optimizer": {
+            "enabled": true,
+            "runs": 200
+        },
+        "outputSelection": {
+            "*": {
+                "*": [
+                    "abi",
+                    "evm.bytecode",
+                    "evm.deployedBytecode"
+                ],
+                "": ["ast"]
+            }
+        },
+        "metadata": {
+            "bytecodeHash": "none"
+        }
     }
-  },
-  "settings": {
-    "optimizer": {
-      "enabled": true,
-      "runs": 200
-    },
-    "outputSelection": {
-      "*": {
-        "*": [
-          "abi",
-          "evm.bytecode",
-          "evm.deployedBytecode"
-        ],
-        "": ["ast"]
-      }
-    },
-    "metadata": {
-      "bytecodeHash": "none"
-    }
-  }
 }

--- a/config/dev.json
+++ b/config/dev.json
@@ -1,37 +1,37 @@
 {
-  "language": "Solidity",
-  "sources": {
-    "contracts/ProxyFactory.sol": {
-      "urls": ["contracts/ProxyFactory.sol"]
+    "language": "Solidity",
+    "sources": {
+        "contracts/ProxyFactory.sol": {
+            "urls": ["contracts/ProxyFactory.sol"]
+        },
+        "contracts/test/ProxyFactory.t.sol": {
+            "urls": ["contracts/test/ProxyFactory.t.sol"]
+        },
+        "contracts/test/SlotManipulatable.t.sol": {
+            "urls": [
+                "contracts/test/SlotManipulatable.t.sol"
+            ]
+        }
     },
-    "contracts/test/ProxyFactory.t.sol": {
-      "urls": ["contracts/test/ProxyFactory.t.sol"]
-    },
-    "contracts/test/SlotManipulatable.t.sol": {
-      "urls": [
-        "contracts/test/SlotManipulatable.t.sol"
-      ]
+    "settings": {
+        "optimizer": {
+            "enabled": true,
+            "runs": 200
+        },
+        "outputSelection": {
+            "*": {
+                "*": [
+                    "abi",
+                    "metadata",
+                    "evm.bytecode",
+                    "evm.deployedBytecode",
+                    "evm.gasEstimates"
+                ],
+                "": ["ast"]
+            }
+        },
+        "metadata": {
+            "bytecodeHash": "none"
+        }
     }
-  },
-  "settings": {
-    "optimizer": {
-      "enabled": true,
-      "runs": 200
-    },
-    "outputSelection": {
-      "*": {
-        "*": [
-          "abi",
-          "metadata",
-          "evm.bytecode",
-          "evm.deployedBytecode",
-          "evm.gasEstimates"
-        ],
-        "": ["ast"]
-      }
-    },
-    "metadata": {
-      "bytecodeHash": "none"
-    }
-  }
 }

--- a/config/prod.json
+++ b/config/prod.json
@@ -1,31 +1,31 @@
 {
-  "language": "Solidity",
-  "sources": {
-    "contracts/ProxyFactory.sol": {
-      "urls": ["contracts/ProxyFactory.sol"]
-    }
-  },
-  "settings": {
-    "optimizer": {
-      "enabled": true,
-      "runs": 200
+    "language": "Solidity",
+    "sources": {
+        "contracts/ProxyFactory.sol": {
+            "urls": ["contracts/ProxyFactory.sol"]
+        }
     },
-    "outputSelection": {
-      "*": {
-        "*": [
-          "abi",
-          "devdoc",
-          "userdoc",
-          "metadata",
-          "evm.bytecode",
-          "evm.deployedBytecode",
-          "evm.gasEstimates"
-        ],
-        "": ["ast"]
-      }
-    },
-    "metadata": {
-      "bytecodeHash": "none"
+    "settings": {
+        "optimizer": {
+            "enabled": true,
+            "runs": 200
+        },
+        "outputSelection": {
+            "*": {
+                "*": [
+                    "abi",
+                    "devdoc",
+                    "userdoc",
+                    "metadata",
+                    "evm.bytecode",
+                    "evm.deployedBytecode",
+                    "evm.gasEstimates"
+                ],
+                "": ["ast"]
+            }
+        },
+        "metadata": {
+            "bytecodeHash": "none"
+        }
     }
-  }
 }

--- a/contracts/Proxied.sol
+++ b/contracts/Proxied.sol
@@ -24,8 +24,13 @@ contract Proxied is SlotManipulatable {
         ( success_, ) = migrator_.delegatecall(arguments_);
     }
 
-    function _setImplementation(address newImplementation_) internal virtual returns (bool success_) {
-        _setSlotValue(IMPLEMENTATION_SLOT, bytes32(uint256(uint160(newImplementation_))));
+    function _setFactory(address factory_) internal virtual returns (bool success_) {
+        _setSlotValue(FACTORY_SLOT, bytes32(uint256(uint160(factory_))));
+        return true;
+    }
+
+    function _setImplementation(address implementation_) internal virtual returns (bool success_) {
+        _setSlotValue(IMPLEMENTATION_SLOT, bytes32(uint256(uint160(implementation_))));
         return true;
     }
 

--- a/contracts/Proxy.sol
+++ b/contracts/Proxy.sol
@@ -28,13 +28,13 @@ contract Proxy is SlotManipulatable {
     fallback() payable external virtual {
         bytes32 implementation = _getSlotValue(IMPLEMENTATION_SLOT);
 
-        int256 size;
+        uint256 size;
 
         assembly {
             size := extcodesize(implementation)
         }
 
-        require(size != 0, "P:F:INVALID_IMPLEMENTATION");
+        require(size != uint256(0), "P:F:INVALID_IMPLEMENTATION");
 
         assembly {
             calldatacopy(0, 0, calldatasize())

--- a/contracts/ProxyFactory.sol
+++ b/contracts/ProxyFactory.sol
@@ -8,20 +8,22 @@ import { Proxy } from "./Proxy.sol";
 /// @title A factory for Proxy contracts that proxy Proxied implementations.
 contract ProxyFactory {
 
-    bytes32 internal constant PROXY_CODE_HASH = keccak256(type(Proxy).runtimeCode);
-
     mapping(uint256 => address) internal _implementationOf;
 
     mapping(address => uint256) internal _versionOf;
 
     mapping(uint256 => mapping(uint256 => address)) internal _migratorForPath;
 
-    function _initializeInstance(address proxy_, uint256 version_, bytes memory arguments_) internal virtual returns (bool success_) {
-        if (!_isContract(proxy_)) return false;
+    function _getImplementationOfProxy(address proxy_) private view returns (bool success_, address implementation_) {
+        bytes memory returnData;
+        ( success_, returnData ) = proxy_.staticcall(abi.encodeWithSelector(IProxied.implementation.selector));
+        implementation_ = abi.decode(returnData, (address));
+    }
 
+    function _initializeInstance(address proxy_, uint256 version_, bytes memory arguments_) private returns (bool success_) {
         address initializer = _migratorForPath[version_][version_];
 
-        if (initializer == address(0)) return true;
+        if (initializer == address(0)) return arguments_.length == uint256(0);
 
         ( success_, ) = proxy_.call(abi.encodeWithSelector(IProxied.migrate.selector, initializer, arguments_));
     }
@@ -29,34 +31,39 @@ contract ProxyFactory {
     function _newInstance(uint256 version_, bytes memory arguments_) internal virtual returns (bool success_, address proxy_) {
         address implementation = _implementationOf[version_];
 
-        success_ =
-            implementation != address(0) &&
-            _initializeInstance(proxy_ = address(new Proxy(address(this), implementation)), version_, arguments_);
+        if (implementation == address(0)) return (false, address(0));
+
+        proxy_   = address(new Proxy(address(this), implementation));
+        success_ = _initializeInstance(proxy_, version_, arguments_);
     }
 
-    function _newInstance(uint256 version_, bytes memory arguments_, bytes32 salt_) internal virtual returns (bool success_, address proxy_) {
-        address implementation = _implementationOf[version_];
+    function _newInstance(bytes memory arguments_, bytes32 salt_) internal virtual returns (bool success_, address proxy_) {
+        proxy_ = address(new Proxy{ salt: salt_ }(address(this), address(0)));
 
-        success_ =
-            implementation != address(0) &&
-            _initializeInstance(proxy_ = address(new Proxy{ salt: salt_ }(address(this), address(0))), version_, arguments_);
+        ( , address implementation ) = _getImplementationOfProxy(proxy_);
+
+        uint256 version = _versionOf[implementation];
+
+        success_ = (version != uint256(0)) && _initializeInstance(proxy_, version, arguments_);
     }
 
-    function _registerImplementation(uint256 version_, address implementationAddress_) internal virtual returns (bool success_) {
-        // Cannot already be registered and cannot be empty implementation.
+    function _registerImplementation(uint256 version_, address implementation_) internal virtual returns (bool success_) {
         if (
-            _implementationOf[version_] != address(0) || 
-            _versionOf[implementationAddress_] != 0   || 
-            !_isContract(implementationAddress_)
+            version_ == uint256(0) ||
+            _implementationOf[version_] != address(0) ||
+            _versionOf[implementation_] != uint256(0) ||
+            !_isContract(implementation_)
         ) return false;
 
-        _versionOf[implementationAddress_] = version_;
-        _implementationOf[version_]        = implementationAddress_;
+        _implementationOf[version_] = implementation_;
+        _versionOf[implementation_] = version_;
 
         return true;
     }
 
     function _registerMigrator(uint256 fromVersion_, uint256 toVersion_, address migrator_) internal virtual returns (bool success_) {
+        if (fromVersion_ == uint256(0) || toVersion_ == uint256(0)) return false;
+
         if (migrator_ != address(0) && !_isContract(migrator_)) return false;
 
         _migratorForPath[fromVersion_][toVersion_] = migrator_;
@@ -71,9 +78,8 @@ contract ProxyFactory {
 
         if (toImplementation == address(0)) return false;
 
-        bytes memory returnData;
-
-        ( success_, returnData ) = proxy_.call(abi.encodeWithSelector(IProxied.implementation.selector));
+        address fromImplementation;
+        ( success_, fromImplementation ) = _getImplementationOfProxy(proxy_);
 
         if (!success_) return false;
 
@@ -81,15 +87,14 @@ contract ProxyFactory {
 
         if (!success_) return false;
 
-        // Get the "fromImplementation" from `returnData`, then the version of the "fromImplementation", then get the `migrator` of the upgrade path.
-        address migrator = _migratorForPath[_versionOf[abi.decode(returnData, (address))]][toVersion_];
+        address migrator = _migratorForPath[_versionOf[fromImplementation]][toVersion_];
 
-        if (migrator == address(0)) return true;
+        if (migrator == address(0)) return arguments_.length == uint256(0);
 
         ( success_, ) = proxy_.call(abi.encodeWithSelector(IProxied.migrate.selector, migrator, arguments_));
     }
 
-    function _getDeterministicProxyAddress(bytes32 salt_) internal virtual view returns (address proxyAddress_) {
+    function _getDeterministicProxyAddress(bytes32 salt_) internal virtual view returns (address deterministicProxyAddress_) {
         // See https://docs.soliditylang.org/en/v0.8.7/control-structures.html#salted-contract-creations-create2
         return address(
             uint160(
@@ -107,7 +112,7 @@ contract ProxyFactory {
         );
     }
 
-    function _isContract(address account_) internal view returns (bool) {
+    function _isContract(address account_) internal view returns (bool isContract_) {
         uint256 size;
 
         assembly {

--- a/contracts/ProxyFactory.sol
+++ b/contracts/ProxyFactory.sol
@@ -14,20 +14,28 @@ contract ProxyFactory {
 
     mapping(uint256 => mapping(uint256 => address)) internal _migratorForPath;
 
+    /// @notice Returns the implementation of `proxy_`.
     function _getImplementationOfProxy(address proxy_) private view returns (bool success_, address implementation_) {
         bytes memory returnData;
+        // Since `_getImplementationOfProxy` is a private function, no need to check `proxy_` is a contract.
         ( success_, returnData ) = proxy_.staticcall(abi.encodeWithSelector(IProxied.implementation.selector));
         implementation_ = abi.decode(returnData, (address));
     }
 
+    /// @notice Initializes `proxy_` using the initializer for `version_`, given some initialization arguments.
     function _initializeInstance(address proxy_, uint256 version_, bytes memory arguments_) private returns (bool success_) {
+        // The migrator, where fromVersion == toVersion, is an initializer.
         address initializer = _migratorForPath[version_][version_];
 
+        // If there is no initializer, then no initialization is necessary, so long as no initialization arguments were provided.
         if (initializer == address(0)) return arguments_.length == uint256(0);
 
+        // Call the migrate function on the proxy, passing any initialization arguments.
+        // Since `_initializeInstance` is a private function, no need to check `proxy_` is a contract.
         ( success_, ) = proxy_.call(abi.encodeWithSelector(IProxied.migrate.selector, initializer, arguments_));
     }
 
+    /// @notice Deploys a new proxy for some version, with some initialization arguments, using `create` (i.e. factory's nonce determines the address).
     function _newInstance(uint256 version_, bytes memory arguments_) internal virtual returns (bool success_, address proxy_) {
         address implementation = _implementationOf[version_];
 
@@ -37,17 +45,25 @@ contract ProxyFactory {
         success_ = _initializeInstance(proxy_, version_, arguments_);
     }
 
+    /// @notice Deploys a new proxy, with some initialization arguments, using `create2` (i.e. salt determines the address).
+    /// @dev    This factory needs to be IDefaultImplementationBeacon, since the proxy will pull its implementation from it.
     function _newInstance(bytes memory arguments_, bytes32 salt_) internal virtual returns (bool success_, address proxy_) {
         proxy_ = address(new Proxy{ salt: salt_ }(address(this), address(0)));
 
+        // Fetch the implementation from the proxy. Don't care about success, since the version of the implementation will be checked in the nest step.
         ( , address implementation ) = _getImplementationOfProxy(proxy_);
 
+        // Get the version of the implementation.
         uint256 version = _versionOf[implementation];
 
+        // Successful if version is nonzero (i.e. implementation fetched successfully from proxy) and initializing the instance succeeds.
         success_ = (version != uint256(0)) && _initializeInstance(proxy_, version, arguments_);
     }
 
+    /// @notice Registers an implementation for some version.
     function _registerImplementation(uint256 version_, address implementation_) internal virtual returns (bool success_) {
+        // Version 0 is not allowed since its the default value of all _versionOf[implementation_].
+        // Implementation cannot already be registered and cannot be empty account (and thus also not address(0)).
         if (
             version_ == uint256(0) ||
             _implementationOf[version_] != address(0) ||
@@ -55,15 +71,19 @@ contract ProxyFactory {
             !_isContract(implementation_)
         ) return false;
 
+        // Store in two-way mappings.
         _implementationOf[version_] = implementation_;
         _versionOf[implementation_] = version_;
 
         return true;
     }
 
+    /// @notice Registers a migrator for between two versions. If `fromVersion_ == toVersion_`, migrator is an initializer.
     function _registerMigrator(uint256 fromVersion_, uint256 toVersion_, address migrator_) internal virtual returns (bool success_) {
+        // Version 0 is invalid.
         if (fromVersion_ == uint256(0) || toVersion_ == uint256(0)) return false;
 
+        // Migrator must either be zero (clearing) or a contract (setting).
         if (migrator_ != address(0) && !_isContract(migrator_)) return false;
 
         _migratorForPath[fromVersion_][toVersion_] = migrator_;
@@ -71,29 +91,39 @@ contract ProxyFactory {
         return true;
     }
 
+    /// @notice Upgrades a proxy to a new version of an implementation, with some migration arguments.
+    /// @dev    Inheritor should revert on `success_ = false`, since proxy can be set to new implementation, but failed to migrate.
     function _upgradeInstance(address proxy_, uint256 toVersion_, bytes memory arguments_) internal virtual returns (bool success_) {
+        // Check that the proxy is currently a contract, just once, ahead of the 3 times it will be low-level-called.
         if (!_isContract(proxy_)) return false;
 
         address toImplementation = _implementationOf[toVersion_];
 
+        // The implementation being migrated must have been registered (which also implies that `toVersion_` was not 0).
         if (toImplementation == address(0)) return false;
 
+        // Fetch the implementation from the proxy.
         address fromImplementation;
         ( success_, fromImplementation ) = _getImplementationOfProxy(proxy_);
 
         if (!success_) return false;
 
+        // Set the proxy's implementation.
         ( success_, ) = proxy_.call(abi.encodeWithSelector(IProxied.setImplementation.selector, toImplementation));
 
         if (!success_) return false;
 
+        // Get the version of the `fromImplementation`, then get the `migrator` of the upgrade path to `toVersion_`.
         address migrator = _migratorForPath[_versionOf[fromImplementation]][toVersion_];
 
+        // If there is no migrator, then no migration is necessary, so long as no migration arguments were provided.
         if (migrator == address(0)) return arguments_.length == uint256(0);
 
+        // Call the migrate function on the proxy, passing any migration arguments.
         ( success_, ) = proxy_.call(abi.encodeWithSelector(IProxied.migrate.selector, migrator, arguments_));
     }
 
+    /// @notice Returns the deterministic address of a proxy given some salt.
     function _getDeterministicProxyAddress(bytes32 salt_) internal virtual view returns (address deterministicProxyAddress_) {
         // See https://docs.soliditylang.org/en/v0.8.7/control-structures.html#salted-contract-creations-create2
         return address(
@@ -112,6 +142,7 @@ contract ProxyFactory {
         );
     }
 
+    /// @notice Returns whether the account is currently a contract.
     function _isContract(address account_) internal view returns (bool isContract_) {
         uint256 size;
 

--- a/contracts/test/ProxyFactory.t.sol
+++ b/contracts/test/ProxyFactory.t.sol
@@ -219,8 +219,8 @@ contract ProxyFactoryTests is DSTest {
 
         bytes32 salt = keccak256(abi.encodePacked("salt"));
 
-        IMockImplementationV2 proxy = IMockImplementationV2(factory.newInstance(2, abi.encode(uint256(9090)), salt));
-        
+        IMockImplementationV2 proxy = IMockImplementationV2(factory.newInstance(abi.encode(uint256(9090)), salt));
+
         assertEq(proxy.factory(),        address(factory));
         assertEq(proxy.implementation(), address(implementation));
     }
@@ -234,7 +234,7 @@ contract ProxyFactoryTests is DSTest {
         bytes32 salt = keccak256(abi.encodePacked("salt"));
 
         assertEq(factory.getDeterministicProxyAddress(salt), 0x01E7fFbDA7F30087c376259c0771577D4c4a57b1);
-        assertEq(factory.newInstance(1, new bytes(0), salt), 0x01E7fFbDA7F30087c376259c0771577D4c4a57b1);
+        assertEq(factory.newInstance(new bytes(0), salt),    0x01E7fFbDA7F30087c376259c0771577D4c4a57b1);
     }
 
     function test_newInstance_withSaltAndInvalidInitializerArguments() external {
@@ -251,14 +251,14 @@ contract ProxyFactoryTests is DSTest {
 
         bytes32 salt = keccak256(abi.encodePacked("salt"));
 
-        try factory.newInstance(2, new bytes(0), salt) { assertTrue(false, "Able to create with invalid arguments"); } catch { }
+        try factory.newInstance(new bytes(0), salt) { assertTrue(false, "able to create"); } catch { }
 
-        factory.newInstance(2, abi.encode(0), salt);
+        factory.newInstance(abi.encode(0), salt);
     }
 
     function testFail_newInstance_withSaltAndNonRegisteredImplementation() external {
         MockFactory factory = new MockFactory();
-        factory.newInstance(1, new bytes(0), keccak256(abi.encodePacked("salt")));
+        factory.newInstance(new bytes(0), keccak256(abi.encodePacked("salt")));
     }
 
     function testFail_newInstance_withReusedSalt() external {
@@ -268,8 +268,8 @@ contract ProxyFactoryTests is DSTest {
         bytes32 salt = keccak256(abi.encodePacked("salt"));
 
         factory.registerImplementation(1, address(implementation));
-        factory.newInstance(1, new bytes(0), salt);
-        factory.newInstance(1, new bytes(0), salt);
+        factory.newInstance(new bytes(0), salt);
+        factory.newInstance(new bytes(0), salt);
     }
 
     /******************************/
@@ -489,7 +489,7 @@ contract ProxyFactoryTests is DSTest {
 
         // Check state before migration.
         assertEq(IMockImplementationV1(proxy).implementation(), address(implementationV1));
-   
+
         // Try migrate proxy from V1 to V2.
         try factory.upgradeInstance(proxy, 2, new bytes(0)) { assertTrue(false, "Able to migrate with invalid arguments"); } catch { }
 
@@ -549,7 +549,7 @@ contract ProxyFactoryTests is DSTest {
 
         IMockImplementationV1 proxy = IMockImplementationV1(factory.newInstance(1, new bytes(0)));
 
-        try proxy.alpha() { assertTrue(false, "Proxy didn't revert"); } catch { } 
+        try proxy.alpha() { assertTrue(false, "Proxy didn't revert"); } catch { }
     }
 
 }

--- a/contracts/test/mocks/Mocks.sol
+++ b/contracts/test/mocks/Mocks.sol
@@ -24,8 +24,8 @@ contract MockFactory is IDefaultImplementationBeacon, ProxyFactory {
         return _versionOf[proxy_];
     }
 
-    function registerImplementation(uint256 version_, address implementationAddress_) external {
-        require(_registerImplementation(version_, defaultImplementation = implementationAddress_));
+    function registerImplementation(uint256 version_, address implementation_) external {
+        require(_registerImplementation(version_, defaultImplementation = implementation_));
     }
 
     function newInstance(uint256 version_, bytes calldata initializationArguments_) external returns (address proxy_) {
@@ -34,9 +34,9 @@ contract MockFactory is IDefaultImplementationBeacon, ProxyFactory {
         require(success);
     }
 
-    function newInstance(uint256 version_, bytes calldata initializationArguments_, bytes32 salt_) external returns (address proxy_) {
+    function newInstance(bytes calldata initializationArguments_, bytes32 salt_) external returns (address proxy_) {
         bool success;
-        ( success, proxy_ ) = _newInstance(version_, initializationArguments_, salt_);
+        ( success, proxy_ ) = _newInstance(initializationArguments_, salt_);
         require(success);
     }
 


### PR DESCRIPTION
- int256 -> uint256 contract size in Proxy
- removed deprecated `PROXY_CODE_HASH` from Factory
- made `_initializeInstance` private and only called internally, so no need to check proxy contract size
- moved reused code into a private `_getImplementationOfProxy` function that also does not need to check proxy contract size
- `_initializeInstance` and `_upgradeInstance` now return false if no initializer/migrator but has arguments
- all deploys and calls low-level in order to not have reverts and bubble up all successes to inheritor
- cleaned up logic and optimized
- version 0 now explicitly banned
- added many comments

# Description

# Integrations Checklist

- [ ] Have any function signatures changed? If yes, outline below.
- [ ] Have any features changed or been added? If yes, outline below.
- [ ] Have any events changed or been added? If yes, outline below.
- [ ] Has all documentation been updated?

# Changelog
## Function Signature Changes

## Features 

## Events

